### PR TITLE
[Bug Fix] Use chain ticker for gas

### DIFF
--- a/src_genericwallet/main.c
+++ b/src_genericwallet/main.c
@@ -2354,8 +2354,8 @@ void handleSign(uint8_t p1, uint8_t p2, uint8_t *workBuffer,
                    (char *)G_io_apdu_buffer, 100, WEI_TO_ETHER);
     i = 0;
     tickerOffset = 0;
-    while (ticker[tickerOffset]) {
-        maxFee[tickerOffset] = ticker[tickerOffset];
+    while (TICKER_ETH[tickerOffset]) {
+        maxFee[tickerOffset] = TICKER_ETH[tickerOffset];
         tickerOffset++;
     }
     tickerOffset++;


### PR DESCRIPTION
For ERC20 Token transactions, the app currently displays `TOKEN xxx` for the Maximum Gas price. This PR fixes this to show `ETH xxx` (Or whichever chain is specified).