### PR TITLE
Fix: Add ETH derivation path to Wanchain 

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -88,7 +88,8 @@ APP_LOAD_PARAMS += --path "44'/200625'"
 DEFINES += CHAINID_UPCASE=\"AKA\" CHAINID_COINNAME=\"AKA\" CHAIN_KIND=CHAIN_KIND_AKROMA CHAIN_ID=200625
 APPNAME = "Akroma"
 else ifeq ($(CHAIN),wanchain)
-APP_LOAD_PARAMS += --path "44'/5718350'"
+# Also allows Wanchain to access the ETH derivation path to recover pre-ledger-live assets
+APP_LOAD_PARAMS += --path "44'/5718350'" --path "44'/60'"
 DEFINES += CHAINID_UPCASE=\"WAN\" CHAINID_COINNAME=\"WAN\" CHAIN_KIND=CHAIN_KIND_WANCHAIN CHAIN_ID=1
 APPNAME = "Wanchain"
 else ifeq ($(CHAIN),kusd)


### PR DESCRIPTION
Add ETH derivation path to Wanchain to allow users to recover assets sent to ETH address. We've had multiple requests from people that used the ETH derivation path before the ledger live change to fix the derivation path. To recover those assets we would like to allow the ETH derivation path as well on MyWanWallet together with the ledger.